### PR TITLE
bump version number

### DIFF
--- a/plugin-src/setup.py
+++ b/plugin-src/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 PACKAGE = 'TracAdvancedSearch'
-VERSION = '0.3'
+VERSION = '0.4'
 
 setup(name=PACKAGE,
 	version=VERSION,


### PR DESCRIPTION
The commit (dated May 23rd, but I'm told it was done today) changing the query behavior of "*" should really get a version number bump.

Also, please start creating version tags.
