### PR TITLE
fix a localized date string issue and add new config options to use user defined ticket status

### DIFF
--- a/tracadvsearch/backend.py
+++ b/tracadvsearch/backend.py
@@ -131,7 +131,7 @@ class PySolrSearchBackEnd(Component):
 		def safe_decode(date_string):
 			if isinstance(date_string, str):
 				lang, encoding = locale.getlocale()
-				encoding = encoding if encoding else self.EFAULT_DATE_ENCODING
+				encoding = encoding if encoding else self.DEFAULT_DATE_ENCODING
 				return unicode(date_string, encoding)
 			return date_string
 

--- a/tracadvsearch/backend.py
+++ b/tracadvsearch/backend.py
@@ -3,6 +3,7 @@ Backends for TracAdvancedSearchPlugin which implement IAdvSearchBackend.
 """
 import datetime
 import itertools
+import locale
 import pysolr
 import time
 
@@ -19,6 +20,7 @@ class PySolrSearchBackEnd(Component):
 
 	SOLR_DATE_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 	INPUT_DATE_FORMAT = "%a %b %d %Y"
+	DEFAULT_DATE_ENCODING = "utf-8"
 
 	SPECIAL_CHARACTERS = r'''+-&|!(){}[]^"~*?:\\'''
 
@@ -126,8 +128,15 @@ class PySolrSearchBackEnd(Component):
 
 	def _date_from_solr(self, date_string):
 		"""Return a human friendly date from solr date string."""
+		def safe_decode(date_string):
+			if isinstance(date_string, str):
+				lang, encoding = locale.getlocale()
+				encoding = encoding if encoding else self.EFAULT_DATE_ENCODING
+				return unicode(date_string, encoding)
+			return date_string
+
 		date = self._strptime(date_string, self.SOLR_DATE_FORMAT)
-		return date.strftime(self.INPUT_DATE_FORMAT)
+		return safe_decode(date.strftime(self.INPUT_DATE_FORMAT))
 
 	def _string_from_input(self, value):
 		"""Return a value string formatted in solr query syntax."""


### PR DESCRIPTION
This pull request resolve 2 problems. Could you review it?
## fix to decode the date string from solr

The datetime.strftime() might return encoded date string depending on locale. And Genshi expects the unicode string.

``` python
>>> import locale
>>> import datetime
>>> locale.getlocale()
(None, None)
>>> print datetime.datetime.now().strftime("%a %b %d %Y")
Thu Nov 21 2013
>>> locale.setlocale(locale.LC_ALL, 'ja_JP.UTF-8')
'ja_JP.UTF-8'
>>> locale.getlocale()
('ja_JP', 'UTF-8')
>>> print datetime.datetime.now().strftime("%a %b %d %Y")
木 11月 21 2013
```
## add 'ticket_status' and 'ticket_status_enable' config options

We use the custom ticket status for our purpose. The plugin handles only default ticket values. So, it doesn't show search result if the ticket status is not default.

``` python
('new', 'assigned', 'reopened', 'closed')
```
