### PR TITLE
Add Asynchronous index mechanism implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,16 @@ menu_label = Real Search
 
 button_label and timeout are both optional.
 
+The default pysolr backend queries to solr for indexing synchronously.
+If you want to do indexing asynchronously, add like this:
+
+```
+[pysolr_search_backend]
+async_indexing = true
+async_queue_maxsize = 10000  # if 0, the queue size is infinity
+...
+```
+
 You'll also need to enable the components.
 
 ```

--- a/solr/conf/data-config-for-sqlite.xml
+++ b/solr/conf/data-config-for-sqlite.xml
@@ -2,7 +2,7 @@
   Data Import Configuration
 
   This will load all your existing ticket and wiki data into the solr index.
-  If you use a database other then mysql you may need to change the queries
+  If you use a database other then sqlite you may need to change the queries
   slightly. You will likely have to change the connection url as well.
 
   To start this data import hit the following url (assumes solr is running

--- a/solr/conf/data-config-for-sqlite.xml
+++ b/solr/conf/data-config-for-sqlite.xml
@@ -1,0 +1,67 @@
+<!--
+  Data Import Configuration
+
+  This will load all your existing ticket and wiki data into the solr index.
+  If you use a database other then mysql you may need to change the queries
+  slightly. You will likely have to change the connection url as well.
+
+  To start this data import hit the following url (assumes solr is running
+  on the default port on localhost):
+  http://localhost:8983/solr/dataimport?command=full-import
+
+  For more details see:
+  http://wiki.apache.org/solr/DataImportHandler
+-->
+<dataConfig>
+
+	<dataSource
+		type="JdbcDataSource"
+		driver="org.sqlite.JDBC"
+		url="jdbc:sqlite:/path/to/db/trac.db"
+		batchSize="1000"
+	/>
+
+	<document>
+		<entity
+			name="wiki"
+			query="select
+				name,
+				version,
+				replace(datetime(round(time/1000000), 'unixepoch'), ' ', 'T')||'Z' AS time,
+				author,
+				text,
+				comment,
+				'wiki_'||name as id,
+				'wiki' as source
+				from wiki
+				order by time asc">
+		</entity>
+		<entity
+			name="ticket"
+			query="select
+				'ticket_'||id as id,
+				id as ticket_id,
+				'ticket' as source,
+				type,
+				replace(datetime(round(t.time/1000000), 'unixepoch'), ' ', 'T')||'Z' AS time,
+				replace(datetime(round(t.changetime/1000000), 'unixepoch'), ' ', 'T')||'Z' AS changetime,
+				component,
+				severity,
+				priority,
+				owner,
+				cc,
+				reporter as author,
+				version as ticket_version,
+				milestone,
+				status,
+				resolution,
+				summary as name,
+				keywords,
+				description||group_concat(newvalue, ' ') as text
+				FROM ticket as t LEFT JOIN ticket_change as tc ON t.id=tc.ticket and tc.field='comment'
+				GROUP BY t.id
+				">
+		</entity>
+	</document>
+
+</dataConfig>

--- a/tracadvsearch/backend.py
+++ b/tracadvsearch/backend.py
@@ -135,8 +135,7 @@ class AsyncSolrIndexer(threading.Thread):
 					method_name, item = self.queue.get(block=True)
 					methodcaller(method_name, item)(self)
 				except Exception, e:
-					import traceback
-					self.backend.log.error(traceback.format_exc(limit=None))
+					self.backend.log.exception(e)
 					self.backend.log.error(item)
 				self.queue.task_done()
 				if not prev_available:

--- a/tracadvsearch/backend.py
+++ b/tracadvsearch/backend.py
@@ -13,6 +13,7 @@ from operator import methodcaller
 
 from advsearch import SearchBackendException
 from interface import IAdvSearchBackend
+from interface import IIndexer
 from trac.config import ConfigurationError
 from trac.core import Component
 from trac.core import implements
@@ -63,40 +64,9 @@ def _get_incremental_value(initial, next_, step):
 			yield next_
 
 
-def implements_indexer(*interfaces):
-	def iter_interface_methods(interface):
-		for key, value in interface.__dict__.items():
-			if callable(value):
-				yield key
-
-	def __metaclass__(name, bases, d):
-		cls = type(name, bases, d)
-		for interface in interfaces:
-			for method in iter_interface_methods(interface):
-				try:
-					getattr(cls, method)
-				except AttributeError:
-					_msg = "Missing method %r on %r from interface %r" % (method, cls, interface)
-					raise NotImplementedError(_msg)
-		return cls
-
-	cls_scope = sys._getframe(1).f_locals
-	cls_scope['__metaclass__'] = __metaclass__
-
-
-class IIndexer(object):
-	"""Interface to provides indexing process for PySolrSearchBackEnd."""
-
-	def upsert(self, doc):
-		"""Indexing to insert or update a document."""
-
-	def delete(self, identifier):
-		"""Indexing to remove a document."""
-
-
 class SolrIndexer(object):
 	"""Synchronous Indexer for PySolrSearchBackEnd."""
-	implements_indexer(IIndexer)
+	implements(IIndexer)
 
 	def __init__(self, backend):
 		self.backend = backend
@@ -135,7 +105,7 @@ class SimpleLifoQueue(list):
 
 class AsyncSolrIndexer(threading.Thread):
 	"""Asynchronous Indexer for PySolrSearchBackEnd."""
-	implements_indexer(IIndexer)
+	implements(IIndexer)
 
 	SLEEP_INTERVAL = (60, 3600, 10)
 

--- a/tracadvsearch/backend.py
+++ b/tracadvsearch/backend.py
@@ -90,7 +90,7 @@ class SimpleLifoQueue(list):
 		self.maxsize = maxsize
 
 	def put(self, item):
-		if len(self) >= self.maxsize:
+		if self.maxsize > 0 and len(self) >= self.maxsize:
 			raise Queue.Full
 		self.append(item)
 

--- a/tracadvsearch/interface.py
+++ b/tracadvsearch/interface.py
@@ -66,3 +66,12 @@ class IAdvSearchBackend(Interface):
 		"""
 
 
+class IIndexer(Interface):
+	"""Interface to provides indexing process for PySolrSearchBackEnd."""
+
+	def upsert(self, doc):
+		"""Indexing to insert or update a document."""
+
+	def delete(self, identifier):
+		"""Indexing to remove a document."""
+


### PR DESCRIPTION
I implemented the issue #14 with AsyncSolrIndexer uses a thread and a queue. The feature is enabled as follows configuration.

``` ini
[pysolr_search_backend]
async_indexing = true
```

Of course, we can run indexing synchronously for compatibility with SolrIndexer if "async_indexing" is not configured.

Currently, we have operated/verified with this changes in our environment during a few weeks. We will monitor that it works or not for a while, maybe from this month to next month.

Could you review? Any comments are welcome!
