### PR TITLE
Add 2 hook method for comment changes

### DIFF
--- a/tracadvsearch/advsearch.py
+++ b/tracadvsearch/advsearch.py
@@ -399,6 +399,12 @@ class AdvancedSearchPlugin(Component):
 	def ticket_changed(self, ticket, comment, author, old_values):
 		self.ticket_created(ticket)
 
+	def ticket_comment_modified(self, ticket, cdate, author, comment, old_comment):
+		self.ticket_created(ticket)
+
+	def ticket_change_deleted(self, ticket, cdate, changes):
+		self.ticket_created(ticket)
+
 
 class StartPoints(object):
 	"""Format and parse start points for search."""


### PR DESCRIPTION
According to http://trac.edgewall.org/ticket/11377, we can update the index for full-text using these methods. 
- ticket_comment_modified
- ticket_change_deleted

I confirmed it works on 1.0.2dev-r12956.
